### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,20 +23,20 @@
     "test-browsers": "remove-saucelabs-jobs-by-build && zuul test/*.js"
   },
   "dependencies": {
-    "brfs": "^1.2.0",
-    "color": "^0.8.0",
-    "hyperglue": "^2.0.1",
-    "inherits": "^2.0.1",
-    "insert-css": "^0.2.0",
+    "brfs": "1.4.1",
+    "color": "0.8.0",
+    "hyperglue": "2.0.1",
+    "inherits": "2.0.1",
+    "insert-css": "0.2.0",
     "shallow-copy": "0.0.1",
-    "xtend": "^4.0.0"
+    "xtend": "4.0.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",
-    "function-bind": "^1.0.2",
-    "remove-saucelabs-jobs-by-build": "^1.0.0",
-    "svg-sketch-controls": "^1.0.5",
-    "tape": "^4.0.3",
-    "zuul": "^3.2.0"
+    "function-bind": "1.0.2",
+    "remove-saucelabs-jobs-by-build": "1.0.0",
+    "svg-sketch-controls": "1.0.5",
+    "tape": "4.2.0",
+    "zuul": "3.6.0"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>